### PR TITLE
1.5.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -355,7 +355,7 @@ item can be deleted.  Simply raise an exception
 when there is a problem.   By default `can_delete`
 calls `can_update` unless overridden.  See model example.
 
-Can Update
+can_update
 ----------
 
 .. code:: python
@@ -370,7 +370,7 @@ item can be updated.  Simply raise an exception
 when there is a problem or return False.  By default `can_update`
 uses the result from `can_access` unless overridden.
 
-Can Access
+can_access
 ----------
 
 .. code:: python
@@ -401,18 +401,18 @@ To exclude private fields when a user is not the admin.
         return False
 
 
-Updating fields list
---------------------
+update_fields
+-------------
 
 List of model fields to be read from a form or JSON when updating an object.  Normally
 admin fields such as login_counts or security fields are excluded.  Do not put foreign keys or primary
-keys here.
+keys here.  By default, when `update_fields` is empty all Model fields can be updated.
 
 .. code:: python
 
     update_fields = []
 
-Update Properties
+update_properties
 -----------------
 
 When returning a success result from a put or post update, a dict
@@ -441,12 +441,17 @@ Example return JSON:
 This can be used to communicate from the model on the server to the JavaScript code
 interesting things from updates
 
-Creation fields used when creating specification
-------------------------------------------------
+create_fields
+-------------
 
 List of model fields to be read from a form or json when creating an object.  Can be the specified as either 'text' or
 the field. Do not put primary keys here.  Do not put foreign keys here if using SQLAlchemy child insertion.
-This is usually the same as update_fields.
+This is usually the same as `update_fields`.  When `create_fields` is empty all column fields can be inserted.
+
+Used by these methods:
+
+ * request_create_form
+ * get_delete_put_post
 
 .. code:: python
 
@@ -460,6 +465,7 @@ Example:
         id = db.Column(db.Integer, primary_key=True)
 
         setting_type = db.Column(db.String(120), index=True, default='misc')
+        private = db.Column(db.String(3000), default='secret')
         value = db.Column(db.String(3000), default='')
 
         create_fields = [setting_type, 'value']
@@ -975,7 +981,7 @@ Example to create using POST:
 Release Notes
 -------------
 
-* 1.4.3 - Return item from POST/PUT updates. Allow create_fields and update_fields to be specified using the column fields.  None values serialize as null/None.  Restore previous update_properties behaviour
+* 1.4.3 - Return item from POST/PUT updates. Allow create_fields and update_fields to be specified using the column fields.  None values serialize as null/None.  Restore previous update_properties behaviour.  By default updates/creates using all fields.
 * 1.4.2 - by default return all props with update_properties
 * 1.4.1 - Add better exception message when `db` mixin property not set.  Add `FlaskSerialize` factory method.
 * 1.4.0 - Add fs_private_field method.

--- a/README.rst
+++ b/README.rst
@@ -355,8 +355,8 @@ item can be deleted.  Simply raise an exception
 when there is a problem.   By default `can_delete`
 calls `can_update` unless overridden.  See model example.
 
-Update
-------
+Can Update
+----------
 
 .. code:: python
 
@@ -370,8 +370,8 @@ item can be updated.  Simply raise an exception
 when there is a problem or return False.  By default `can_update`
 uses the result from `can_access` unless overridden.
 
-Access
-------
+Can Access
+----------
 
 .. code:: python
 
@@ -417,12 +417,7 @@ Update Properties
 
 When returning a success result from a put or post update, a dict
 composed of the property values from the `update_properties` list is returned
-as "properties".  If not specified the `update_properties` list returns all
-allowable model fields and properties.
-
-.. code:: python
-
-    update_properties = []
+as "properties".
 
 Example return JSON:
 
@@ -663,7 +658,8 @@ Notes:
 Mixin Helper methods and properties
 ===================================
 
-``get_delete_put_post(item_id, user, prop_filters)``
+get_delete_put_post(item_id, user, prop_filters)
+------------------------------------------------
 
 Put, get, delete, post and get-all magic method handler.
 
@@ -676,7 +672,7 @@ Method Operation
 ====== ==============================================================================================================================
 GET    returns one item when `item_id` is a primary key.
 GET    returns all items when `item_id` is None.
-PUT    updates item using `item_id` as the id from request json data.  Calls the model verify before updating.
+PUT    updates item using `item_id` as the id from request json data.  Calls the model verify before updating.  Returns new item as {item}
 DELETE removes the item with primary key of `item_id` if self.can_delete does not throw an error. Returns the item removed.
 POST   creates and returns a Flask response with a new item as json from form body data or JSON body data when `item_id` is None. Calls the model verify method before creating.
 POST   updates an item from form data using `item_id`. Returns json response of {'message':'something'}.  Calls the model verify method before updating.
@@ -964,7 +960,7 @@ Example to create using POST:
 Release Notes
 -------------
 
-* 1.4.3 - Allow create_fields and update_fields to be specified using the column fields.  None values serialize as null/None.
+* 1.4.3 - Return item from POST/PUT updates. Allow create_fields and update_fields to be specified using the column fields.  None values serialize as null/None.  Restore previous update_properties behaviour
 * 1.4.2 - by default return all props with update_properties
 * 1.4.1 - Add better exception message when `db` mixin property not set.  Add `FlaskSerialize` factory method.
 * 1.4.0 - Add fs_private_field method.

--- a/README.rst
+++ b/README.rst
@@ -981,7 +981,7 @@ Example to create using POST:
 Release Notes
 -------------
 
-* 1.4.3 - Return item from POST/PUT updates. Allow create_fields and update_fields to be specified using the column fields.  None values serialize as null/None.  Restore previous update_properties behaviour.  By default updates/creates using all fields.
+* 1.5.0 - Return item from POST/PUT updates. Allow create_fields and update_fields to be specified using the column fields.  None values serialize as null/None.  Restore previous update_properties behaviour.  By default updates/creates using all fields. Exclude primary key from create and update.
 * 1.4.2 - by default return all props with update_properties
 * 1.4.1 - Add better exception message when `db` mixin property not set.  Add `FlaskSerialize` factory method.
 * 1.4.0 - Add fs_private_field method.

--- a/README.rst
+++ b/README.rst
@@ -230,6 +230,10 @@ Create or update from a WTF form:
 
 
 Create a child database object:
+===============================
+
+Using POST.
+-----------
 
 As example: add a `Stat` object to a Survey object using the `request_create_form` convenience method.  The foreign key
 to the parent `Survey` is provided as a `kwargs` parameter to the method.
@@ -240,6 +244,27 @@ to the parent `Survey` is provided as a `kwargs` parameter to the method.
         def stat_add(survey_id=None):
             survey = Survey.query.get_or_404(survey_id)
             return Stat.request_create_form(survey_id=survey.id).as_dict
+
+Using `get_delete_put_post`.
+----------------------------
+
+As example: add a `Stat` object to a Survey object using the `get_delete_put_post` convenience method.  The foreign key
+to the parent `Survey` is provided in the form data as survey_id.  `create_fields` list must then include `survey_id` as
+the foreign key field to be set.
+
+.. code:: html
+
+        <form>
+               <input type="hidden" name="survey_id" value="56">
+               <input name="value">
+        </form>
+
+.. code:: python
+
+        @app.route('/stat/', methods=['POST'])
+        def stat_add():
+            return Stat.get_delete_put_post()
+
 
 Writing and creating
 ====================
@@ -424,12 +449,25 @@ interesting things from updates
 Creation fields used when creating specification
 ------------------------------------------------
 
-List of model fields to be read from a form or json when creating an object.  Do not put foreign keys or primary
-keys here.  This is usually the same as update_fields.
+List of model fields to be read from a form or json when creating an object.  Can be the specified as either 'text' or
+the field. Do not put primary keys here.  Do not put foreign keys here if using SQLAlchemy child insertion.
+This is usually the same as update_fields.
 
 .. code:: python
 
     create_fields = []
+
+Example:
+
+.. code:: python
+
+    class Setting(fs_mixin, FormPageMixin, db.Model):
+        id = db.Column(db.Integer, primary_key=True)
+
+        setting_type = db.Column(db.String(120), index=True, default='misc')
+        value = db.Column(db.String(3000), default='')
+
+        create_fields = [setting_type, 'value']
 
 Update DateTime fields specification
 -------------------------------------
@@ -926,6 +964,7 @@ Example to create using POST:
 Release Notes
 -------------
 
+* 1.4.3 - Allow create_fields and update_fields to be specified using the column fields.  None values serialize as null/None.
 * 1.4.2 - by default return all props with update_properties
 * 1.4.1 - Add better exception message when `db` mixin property not set.  Add `FlaskSerialize` factory method.
 * 1.4.0 - Add fs_private_field method.

--- a/README.rst
+++ b/README.rst
@@ -667,16 +667,20 @@ Put, get, delete, post and get-all magic method handler.
 * `user`: user to user as query filter.
 * `prop_filters`: dictionary of key:value pairs to limit results when returning get-all.
 
-====== ==============================================================================================================================
-Method Operation
-====== ==============================================================================================================================
-GET    returns one item when `item_id` is a primary key.
-GET    returns all items when `item_id` is None.
-PUT    updates item using `item_id` as the id from request json data.  Calls the model verify before updating.  Returns new item as {item}
-DELETE removes the item with primary key of `item_id` if self.can_delete does not throw an error. Returns the item removed.
-POST   creates and returns a Flask response with a new item as json from form body data or JSON body data when `item_id` is None. Calls the model verify method before creating.
-POST   updates an item from form data using `item_id`. Returns json response of {'message':'something'}.  Calls the model verify method before updating.
-====== ==============================================================================================================================
+====== ================================================================================================== ============================
+Method Operation                                                                                          Response
+====== ================================================================================================== ============================
+GET    returns one item when `item_id` is a primary key.                                                  {property1:value1,property2:value2,...}
+GET    returns all items when `item_id` is None.                                                          [{item1},{item2},...]
+PUT    updates item using `item_id` as the id from request json data.  Calls the model `verify` before    {message:message,item:{model_fields,...},properties:{update_properties}}
+       updating.  Returns new item as {item}
+DELETE removes the item with primary key of `item_id` if self.can_delete does not throw an error.         {property1:value1,property2:value2,...}
+       Returns the item removed.  Calls `can_delete` before delete.
+POST   creates and returns a Flask response with a new item as json from form body data or JSON body data {property1:value1,property2:value2,...}
+       when `item_id` is None. Calls the model `verify` method before creating.
+POST   updates an item from form data using `item_id`.                                                    {message:message,item:{model_fields,...},properties:{update_properties}}
+       Calls the model `verify` method before updating.
+====== ================================================================================================== ============================
 
 On error returns a response of 'error message' with http status code of 400.
 
@@ -687,7 +691,8 @@ relationship.
 Prop filters is a dictionary of `property name`:`value` pairs.  Ie: {'group': 'admin'} to restrict list to the
 admin group.  Properties or database fields can be used as the property name.
 
-``as_dict``
+as_dict
+-------
 
 .. code:: python
 
@@ -698,7 +703,8 @@ admin group.  Properties or database fields can be used as the property name.
         :return: dict
         """
 
-``as_json``
+as_json
+-------
 
 .. code:: python
 
@@ -710,7 +716,8 @@ admin group.  Properties or database fields can be used as the property name.
         :return: json object
         """
 
-``before_update``
+before_update(cls, data_dict)
+-----------------------------
 
 .. code:: python
 
@@ -734,7 +741,8 @@ Example, make sure active is 'n' if no value from a request.
         return d
 
 
-``dict_list()``
+dict_list(cls, query_result)
+----------------------------
 
 .. code:: python
 
@@ -745,9 +753,10 @@ Example, make sure active is 'n' if no value from a request.
         :return: list of dict objects
         """
 
-``json_list(query_result)``
+json_list(query_result)
+-----------------------
 
-Return a flask response in json format from a sql alchemy query result.
+Return a flask response in json list format from a sql alchemy query result.
 
 .. code:: python
 
@@ -769,7 +778,8 @@ Example:
         items = Address.query.filter_by(user=current_user)
         return Address.json_list(items)
 
-``json_filter_by(**kw_args)``
+json_filter_by(kw_args)
+-----------------------
 
 Return a flask list response in json format using a filter_by query.
 
@@ -792,7 +802,8 @@ Example:
     def address_list():
         return Address.filter_by(user=current_user)
 
-``json_first(**kwargs)``
+json_first(kwargs)
+------------------
 
 Return the first result in json format using filter_by arguments.
 
@@ -805,7 +816,8 @@ Example:
     def score(course):
         return Score.json_first(class_name=course)
 
-``previous_field_value``
+previous_field_value
+--------------------
 
 A dictionary of the previous field values before an update is applied from a dict, form or json update operation. Helpful
 in the `verify` method to see if field values are to be changed.
@@ -819,7 +831,8 @@ Example:
         if previous_value != self.value:
             current_app.logger.warning(f'value is changing from {previous_value}')
 
-``request_create_form(**kwargs)``
+request_create_form(kwargs)
+---------------------------
 
 Use the contents of a Flask request form or request json data to create a item
 in the database.   Calls verify(create=True).  Returns the new item or throws error.
@@ -837,7 +850,8 @@ Create a score item with the parent being a course.
         course = Course.query.get_or_404(course_id)
         return Score.request_create_form(course_id=course.id).as_dict
 
-``request_update_form()``
+request_update_form()
+---------------------
 
 Use the contents of a Flask request form or request json data to update an item
 in the database.   Calls verify().  Returns True on success.
@@ -876,7 +890,8 @@ Example:
 
 This provides a method and class properties to quickly add a standard way of dealing with WTF forms on a Flask page.
 
-``form_page(cls, item_id=None)``
+form_page(cls, item_id=None)
+----------------------------
 
 Do all the work for creating and editing items using a template and a wtf form.
 

--- a/flask_serialize/flask_serialize.py
+++ b/flask_serialize/flask_serialize.py
@@ -209,6 +209,8 @@ class FlaskSerializeMixin:
         :param value: value to convert
         :return: the new value
         """
+        if value is None:
+            return None
         if isinstance(value, datetime):
             return self.to_date_short(value)
         if isinstance(value, set):
@@ -412,11 +414,15 @@ class FlaskSerializeMixin:
             json_data = request.get_json(force=True)
             if len(json_data) > 0:
                 for field in cls.create_fields:
+                    if cls.db and isinstance(field, cls.db.Column):
+                        field = field.name
                     if field in json_data:
                         value = json_data.get(field)
                         setattr(new_item, field, new_item.__convert_value(field, value))
         except:
             for field in cls.create_fields:
+                if cls.db and isinstance(field, cls.db.Column):
+                    field = field.name
                 if field in request.form:
                     value = request.form.get(field)
                     setattr(new_item, field, new_item.__convert_value(field, value))
@@ -498,6 +504,8 @@ class FlaskSerializeMixin:
             raise Exception('update_fields is empty')
 
         for field in self.update_fields:
+            if self.db and isinstance(field, self.db.Column):
+                field = field.name
             self.previous_field_value[field] = getattr(self, field)
             if field in data_dict:
                 setattr(self, field, self.__convert_value(field, data_dict[field]))

--- a/pypar.commands.sh
+++ b/pypar.commands.sh
@@ -24,5 +24,5 @@ pip install pytest-flask
 
 . venv3/bin/activate
 python setup.py sdist bdist_wheel
-twine check dist/flask_serialize-1.4.3*
-twine upload dist/flask_serialize-1.4.3* -u martlark
+twine check dist/flask_serialize-1.5.0*
+twine upload dist/flask_serialize-1.5.0* -u martlark

--- a/pypar.commands.sh
+++ b/pypar.commands.sh
@@ -24,5 +24,5 @@ pip install pytest-flask
 
 . venv3/bin/activate
 python setup.py sdist bdist_wheel
-twine check dist/flask_serialize-1.4.2*
-twine upload dist/flask_serialize-1.4.2* -u martlark
+twine check dist/flask_serialize-1.4.3*
+twine upload dist/flask_serialize-1.4.3* -u martlark

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '1.4.3'
+VERSION = '1.5.0'
 LONG_DESCRIPTION = open('README.rst', 'r', encoding='utf-8').read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '1.4.2'
+VERSION = '1.4.3'
 LONG_DESCRIPTION = open('README.rst', 'r', encoding='utf-8').read()
 
 setup(

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -272,10 +272,10 @@ def test_update_create_type_conversion(client):
     # default bool type conversion
     # json
     rv = client.put('/setting_update/{}'.format(item.id), json=dict(active=False))
-    assert rv.status_code == 200
-    assert b'Updated' == rv.data
+    assert rv.status_code == 200, rv.data
+    assert b'Updated' == rv.data, rv.data
     item = Setting.query.filter_by(key=key).first()
-    assert 'n' == item.active
+    assert 'n' == item.active, item
     # query parameters as strings so bool converter does not work
     rv = client.put('/setting_update/{}'.format(item.id), query_string=dict(active='y'))
     assert rv.status_code == 200
@@ -443,7 +443,7 @@ def test_create_update_json(client):
     rv = client.post(f'/setting_post/{item.id}',
                      json=dict(setting_type='test', key=key, value=value, number=10,
                                scheduled=dt_now.strftime(Setting.scheduled_date_format)))
-    assert rv.status_code == 200
+    assert rv.status_code == 200, rv.data
     item = Setting.query.filter_by(key=key).first()
     assert item
     assert item.value == value
@@ -455,7 +455,7 @@ def test_create_update_delete(client):
     key = random_string()
     value = random_string()
     rv = client.post('/setting_add', data=dict(setting_type='test', key=key, value=value, number=10))
-    assert rv.status_code == 302
+    assert rv.status_code == 302, rv.data
     item = Setting.query.filter_by(key=key).first()
     assert item
     assert item.value == value
@@ -564,7 +564,7 @@ def test_simple_model_update_fields(client):
     assert b'Updated' in rv.data, rv.data
     # json
     value = random_string()
-    rv = client.put('/simple_edit/{}'.format(item.id), json=dict(value=value))
+    rv = client.put('/simple_edit/{}'.format(item.id), json=dict(value=value, id='dskdsf'))
     assert 200 == rv.status_code, rv.data
     assert rv.json['item']['value'] == value, rv.data
     assert rv.json['item']['prop'] == 'prop:' + value, rv.data

--- a/test/test_flask_app.py
+++ b/test/test_flask_app.py
@@ -4,7 +4,7 @@ import string
 import time
 from datetime import datetime, timedelta
 
-from flask import Flask, redirect, url_for, Response, request, render_template, flash, abort
+from flask import Flask, redirect, url_for, Response, request, render_template, flash
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf import FlaskForm
@@ -193,6 +193,12 @@ def route_setting_form(item_id=None):
     return new_item
 
 
+@app.route('/datetest', methods=['POST'])
+@app.route('/datetest/<int:item_id>', methods=['PUT'])
+def route_datetest(item_id=None):
+    return DateTest.get_delete_put_post(item_id)
+
+
 # =========================
 # MODELS
 # =========================
@@ -238,6 +244,12 @@ class Single(fs_mixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     wang = db.Column(db.String(120), default='wang')
     setting_id = db.Column(db.Integer, db.ForeignKey('setting.id'))
+
+
+class DateTest(fs_mixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    a_date = db.Column(db.DateTime, default=datetime.utcnow)
+    update_fields = create_fields = ['a_date']
 
 
 class Setting(fs_mixin, FormPageMixin, db.Model):

--- a/test/test_flask_app.py
+++ b/test/test_flask_app.py
@@ -261,8 +261,8 @@ class Setting(fs_mixin, FormPageMixin, db.Model):
     single = db.relationship('Single', backref='setting', uselist=False, cascade="all, delete-orphan")
 
     # serializer fields
-    update_fields = ['setting_type', 'value', 'key', 'active', 'number', 'floaty', 'scheduled', 'deci', 'lob']
-    create_fields = ['setting_type', 'value', 'key', 'active', 'user', 'floaty', 'number', 'deci', 'lob']
+    update_fields = [setting_type, 'value', 'key', 'active', 'number', 'floaty', 'scheduled', 'deci', 'lob']
+    create_fields = [setting_type, 'value', 'key', 'active', 'user', 'floaty', 'number', 'deci', 'lob']
     exclude_serialize_fields = ['created']
     exclude_json_serialize_fields = ['updated']
     relationship_fields = ['sub_settings', 'single']

--- a/test/test_flask_app.py
+++ b/test/test_flask_app.py
@@ -77,10 +77,10 @@ def route_sub_setting_get_delete_put_post(item_id=None, user='fake'):
     return SubSetting.get_delete_put_post(item_id, user)
 
 
-@app.route('/bad_add', methods=['POST'])
-@app.route('/bad_edit/<int:item_id>', methods=['PUT', 'POST'])
-def route_bad_get_delete_put_post(item_id=None, user=None):
-    return BadModel.get_delete_put_post(item_id, user)
+@app.route('/simple_add', methods=['POST'])
+@app.route('/simple_edit/<int:item_id>', methods=['PUT', 'POST'])
+def route_simple_get_delete_put_post(item_id=None, user=None):
+    return SimpleModel.get_delete_put_post(item_id, user)
 
 
 @app.route('/setting_get_json/<int:item_id>', methods=['GET'])
@@ -384,12 +384,16 @@ class Setting(fs_mixin, FormPageMixin, db.Model):
         return 'Setting {}'.format(self.key)
 
 
-class BadModel(fs_mixin, db.Model):
+class SimpleModel(fs_mixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     value = db.Column(db.String(30), default='')
 
+    @property
+    def prop(self):
+        return 'prop:' + self.value
+
     def __repr__(self):
-        return '<BadModel %r>' % (self.value)
+        return '<SimpleModel %r>' % (self.value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Return item from POST/PUT updates. Allow create_fields and update_fields to be specified using the column fields.  None values serialize as null/None.  Restore previous update_properties behaviour.  By default updates/creates using all fields. Exclude primary key (id) from create and update.
