### PR TITLE
Bug: Add FlaskSerialize to module exports

### DIFF
--- a/flask_serialize/__init__.py
+++ b/flask_serialize/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from .flask_serialize import FlaskSerializeMixin
+from .flask_serialize import FlaskSerializeMixin, FlaskSerialize
 
-__all__ = ("FlaskSerializeMixin",)
+__all__ = ("FlaskSerializeMixin", "FlaskSerialize")
 __package__ = "flask_serialize"


### PR DESCRIPTION
When trying to use your package according to the 2.0.2 documentation I get an error:

```
ImportError: cannot import name 'FlaskSerialize' from 'flask_serialize'
```

When I dug into it I noticed that your module is not exporting it. I added it to your `__init__.py` so that it can now be used as stated in your documentation.